### PR TITLE
Add additional checks on unbonding transaction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 )
 
 require (
-	github.com/babylonlabs-io/babylon v0.11.0
+	github.com/babylonlabs-io/babylon v0.12.1
 	github.com/babylonlabs-io/networks/parameters v0.2.2
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonlabs-io/babylon v0.11.0 h1:gRJEkjgy3M9bGSY7VjusA84qn6ca8hXa78ss5Z8D3Cc=
-github.com/babylonlabs-io/babylon v0.11.0/go.mod h1:ZOrTde9vs2xoqGTFw4xhupu2CMulnpywiuk0eh4kPOw=
+github.com/babylonlabs-io/babylon v0.12.1 h1:Qfmrq3pdDEZGq6DtMXxwiQjx0HD+t+U0cXQzsJfX15U=
+github.com/babylonlabs-io/babylon v0.12.1/go.mod h1:ZOrTde9vs2xoqGTFw4xhupu2CMulnpywiuk0eh4kPOw=
 github.com/babylonlabs-io/networks/parameters v0.2.2 h1:TCu39fZvjX5f6ZZrjhYe54M6wWxglNewuKu56yE+zrc=
 github.com/babylonlabs-io/networks/parameters v0.2.2/go.mod h1:iEJVOzaLsE33vpP7J4u+CRGfkSIfErUAwRmgCFCBpyI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/signerapp/signer.go
+++ b/signerapp/signer.go
@@ -86,7 +86,7 @@ func (s *SignerApp) SignUnbondingTransaction(
 	stakerUnbondingSig *schnorr.Signature,
 	covnentSignerPubKey *btcec.PublicKey,
 ) (*schnorr.Signature, error) {
-	if err := btcstaking.IsSimpleTransfer(unbondingTx); err != nil {
+	if err := btcstaking.CheckPreSignedUnbondingTxSanity(unbondingTx); err != nil {
 		return nil, wrapInvalidSigningRequestError(err)
 	}
 


### PR DESCRIPTION
- Bump babylon version
- Use new `CheckPreSignedUnbondingTxSanity` stateless function to pre-elimary check unbonding transaction