### PR TITLE
CI: Enable Dockerfile and image scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,13 @@ jobs:
 
   docker_pipeline:
     needs: ["lint_test"]
-    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.6.0
+    uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.12.2
     secrets: inherit
     with:
      publish: true
      dockerfile: ./Dockerfile
      repoName: covenant-signer
+     docker_scan: true
+    permissions:
+      security-events: write
+      packages: read

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# LND < 0.17.0 issue, not fixing
+CVE-2024-27304
+GHSA-7jwh-3vrq-q3m8
+CVE-2024-27289
+CVE-2024-38359


### PR DESCRIPTION
Some remaining CVE that may need analyzed:
<table>
    <tr>
        <th>Package</th>
        <th>ID</th>
        <th>Severity</th>
        <th>Installed Version</th>
        <th>Fixed Version</th>
    </tr>
    <tr>
        <td><code>cosmossdk.io/math</code></td>
        <td>GHSA-7225-m954-23v7</td>
        <td>HIGH</td>
        <td>v1.3.0</td>
        <td>1.4.0</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-p7mv-53f2-4cwj</td>
        <td>HIGH</td>
        <td>v0.38.7</td>
        <td>0.38.15</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-g5xx-c4hv-9ccc</td>
        <td>MEDIUM</td>
        <td>v0.38.7</td>
        <td>0.37.11, 0.38.12</td>
    </tr>
    <tr>
        <td><code>github.com/cometbft/cometbft</code></td>
        <td>GHSA-hg58-rf2h-6rr7</td>
        <td>MEDIUM</td>
        <td>v0.38.7</td>
        <td>0.37.7, 0.38.8</td>
    </tr>
</table>