### PR TITLE
Konradstaniec/max unbodning signing height

### DIFF
--- a/cmd/signerCmd.go
+++ b/cmd/signerCmd.go
@@ -62,6 +62,7 @@ var runSignerCmd = &cobra.Command{
 			signer,
 			chainInfo,
 			parsedGlobalParams,
+			parsedConfig.SignerAppConfig,
 			parsedConfig.BtcNodeConfig.Network,
 		)
 

--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -1,9 +1,12 @@
 package config
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 type SignerAppConfig struct {
-	MaxStakingTransactionHeight uint32 `mapstructure:"max-staking-transaction-height"`
+	MaxStakingTransactionHeight int `mapstructure:"max-staking-transaction-height"`
 }
 
 type ParsedSignerAppConfig struct {
@@ -11,9 +14,16 @@ type ParsedSignerAppConfig struct {
 }
 
 func (c *SignerAppConfig) Parse() (*ParsedSignerAppConfig, error) {
-	// TODO Add some validations
+	if c.MaxStakingTransactionHeight < 0 {
+		return nil, fmt.Errorf("max staking transaction height is too small. Min value is 0")
+	}
+
+	if c.MaxStakingTransactionHeight > math.MaxUint32 {
+		return nil, fmt.Errorf("max staking transaction height is too large. Max value is %d", math.MaxUint32)
+	}
+
 	return &ParsedSignerAppConfig{
-		MaxStakingTransactionHeight: c.MaxStakingTransactionHeight,
+		MaxStakingTransactionHeight: uint32(c.MaxStakingTransactionHeight),
 	}, nil
 }
 

--- a/config/appconfig.go
+++ b/config/appconfig.go
@@ -1,0 +1,24 @@
+package config
+
+import "math"
+
+type SignerAppConfig struct {
+	MaxStakingTransactionHeight uint32 `mapstructure:"max-staking-transaction-height"`
+}
+
+type ParsedSignerAppConfig struct {
+	MaxStakingTransactionHeight uint32
+}
+
+func (c *SignerAppConfig) Parse() (*ParsedSignerAppConfig, error) {
+	// TODO Add some validations
+	return &ParsedSignerAppConfig{
+		MaxStakingTransactionHeight: c.MaxStakingTransactionHeight,
+	}, nil
+}
+
+func DefaultSignerAppConfig() *SignerAppConfig {
+	return &SignerAppConfig{
+		MaxStakingTransactionHeight: math.MaxUint32,
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -138,8 +138,7 @@ port = {{ .Metrics.Port }}
 
 [signer-app-config]
 # The maximum height of staking transaction
-# Max value is 4294967295. Setting it to more than that will result in wrapping
-# around uint32 type.
+# Max value is 4294967295
 max-staking-transaction-height = {{ .SignerAppConfig.MaxStakingTransactionHeight }}
 `
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,10 +17,11 @@ const (
 
 type Config struct {
 	// TODO: Separate config for signing node and for full node
-	BtcNodeConfig   BtcConfig     `mapstructure:"btc-config"`
-	BtcSignerConfig BtcConfig     `mapstructure:"btc-signer-config"`
-	Server          ServerConfig  `mapstructure:"server-config"`
-	Metrics         MetricsConfig `mapstructure:"metrics"`
+	BtcNodeConfig   BtcConfig       `mapstructure:"btc-config"`
+	BtcSignerConfig BtcConfig       `mapstructure:"btc-signer-config"`
+	Server          ServerConfig    `mapstructure:"server-config"`
+	Metrics         MetricsConfig   `mapstructure:"metrics"`
+	SignerAppConfig SignerAppConfig `mapstructure:"signer-app-config"`
 }
 
 func DefaultConfig() *Config {
@@ -29,6 +30,7 @@ func DefaultConfig() *Config {
 		BtcSignerConfig: *DefaultBtcConfig(),
 		Server:          *DefaultServerConfig(),
 		Metrics:         *DefaultMetricsConfig(),
+		SignerAppConfig: *DefaultSignerAppConfig(),
 	}
 }
 
@@ -37,6 +39,7 @@ type ParsedConfig struct {
 	BtcSignerConfig *ParsedBtcConfig
 	ServerConfig    *ParsedServerConfig
 	MetricsConfig   *ParsedMetricsConfig
+	SignerAppConfig *ParsedSignerAppConfig
 }
 
 func (cfg *Config) Parse() (*ParsedConfig, error) {
@@ -63,11 +66,18 @@ func (cfg *Config) Parse() (*ParsedConfig, error) {
 		return nil, err
 	}
 
+	signerAppConfig, err := cfg.SignerAppConfig.Parse()
+
+	if err != nil {
+		return nil, err
+	}
+
 	return &ParsedConfig{
 		BtcNodeConfig:   btcConfig,
 		BtcSignerConfig: btcSignerConfig,
 		ServerConfig:    serverConfig,
 		MetricsConfig:   metricsConfig,
+		SignerAppConfig: signerAppConfig,
 	}, nil
 }
 
@@ -125,6 +135,12 @@ max-content-length = {{ .Server.MaxContentLength }}
 host = "{{ .Metrics.Host }}"
 # The prometheus server port
 port = {{ .Metrics.Port }}
+
+[signer-app-config]
+# The maximum height of staking transaction
+# Max value is 4294967295. Setting it to more than that will result in wrapping
+# around uint32 type.
+max-staking-transaction-height = {{ .SignerAppConfig.MaxStakingTransactionHeight }}
 `
 
 var configTemplate *template.Template

--- a/example/config.toml
+++ b/example/config.toml
@@ -52,3 +52,9 @@ max-content-length = 8192
 host = "127.0.0.1"
 # The prometheus server port
 port = 2112
+
+[signer-app-config]
+# The maximum height of staking transaction
+# Max value is 4294967295. Setting it to more than that will result in wrapping
+# around uint32 type.
+max-staking-transaction-height = 4294967295

--- a/example/config.toml
+++ b/example/config.toml
@@ -55,6 +55,5 @@ port = 2112
 
 [signer-app-config]
 # The maximum height of staking transaction
-# Max value is 4294967295. Setting it to more than that will result in wrapping
-# around uint32 type.
+# Max value is 4294967295
 max-staking-transaction-height = 4294967295

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -104,7 +104,7 @@ func StartManager(
 	appConfig.BtcNodeConfig.Pass = "pass"
 	appConfig.BtcNodeConfig.Network = netParams.Name
 
-	appConfig.SignerAppConfig.MaxStakingTransactionHeight = maxStakingInclusionHeight
+	appConfig.SignerAppConfig.MaxStakingTransactionHeight = int(maxStakingInclusionHeight)
 
 	fakeParsedConfig, err := appConfig.Parse()
 	require.NoError(t, err)


### PR DESCRIPTION
fixes: https://github.com/babylonlabs-io/pm/issues/167

When the phase-2 launches all new stakers will need to unbond through Babylon, thus covenan-signer should have some option to disable sending signatures for late transactions